### PR TITLE
Update par.py

### DIFF
--- a/pypulse/par.py
+++ b/pypulse/par.py
@@ -142,7 +142,7 @@ class Par:
                 retval = self.paramlist[ind].getValue()
             try:
                 return self.numwrap(retval)
-            except TypeError:
+            except (TypeError, d.InvalidOperation):
                 return retval
         return None
     def getPeriod(self):


### PR DESCRIPTION
Decimal throws a Decimal.InvalidOperation exception when trying to parse a string as a decimal.