### PR TITLE
Revert changes to weighting

### DIFF
--- a/pypulse/archive.py
+++ b/pypulse/archive.py
@@ -1678,7 +1678,7 @@ class Archive(object):
             return self.params.getPeriod()
         else:
             P0 = self.polyco.calculatePeriod()
-            return P0
+            #return P0
         
             #print P0,self.params.getPeriod()
             if np.abs(P0) < 1e-5: #Problem with large DT POLYCO values?

--- a/pypulse/archive.py
+++ b/pypulse/archive.py
@@ -814,7 +814,7 @@ class Archive(object):
         """
         Averages the data along the time/polarization/frequency axes
         """
-        self.average_profile = np.mean(np.mean(self.getData(squeeze=False), axis=2), axis=0) #This may not be the appropriate weighting
+        self.average_profile = np.mean(np.mean(self.getData(squeeze=False, weight=False), axis=2), axis=0) #This may not be the appropriate weighting
         if np.shape(self.average_profile)[0] != 1: #polarization add
             if self.subintheader['POL_TYPE'] == "AABBCRCI": #Coherence
                 self.average_profile = (self.average_profile[0, :] +


### PR DESCRIPTION
Changing the means of calculating the average profile and the period seems to have changed the final data relative to the state before pull request #8. These changes keep the results of loading a test file the same as before. 