### PR TITLE
Remove deprecated aliases to np.float and np.int

### DIFF
--- a/pypulse/archive.py
+++ b/pypulse/archive.py
@@ -1160,7 +1160,7 @@ class Archive(object):
         period = self.getPeriod()
         if newshape == ():
             return SP.SinglePulse(func(data), period=period, windowsize=windowsize, **kwargs)
-        retval = np.empty(newshape, dtype=np.object)
+        retval = np.empty(newshape, dtype=object)
         for ind in np.ndindex(newshape):
             pulse = func(data[ind])
             retval[ind] = SP.SinglePulse(pulse, period=period, windowsize=windowsize, **kwargs)
@@ -1328,7 +1328,7 @@ class Archive(object):
         if ax is None:
             fig = plt.figure()
             ax = fig.add_subplot(111)
-        ax.plot(np.arange(len(plotdata), dtype=np.float)/len(plotdata), plotdata, 'k')
+        ax.plot(np.arange(len(plotdata), dtype=float)/len(plotdata), plotdata, 'k')
         ax.set_xlim(0, 1)
         ax.set_xlabel("Pulse Phase")
         unit = self.getDataUnit()

--- a/pypulse/dynamicspectrum.py
+++ b/pypulse/dynamicspectrum.py
@@ -129,7 +129,7 @@ class DynamicSpectrum(object):
             area = np.trapz(hist, x=center)
             shift = -np.min(center)+1.0
             x = center + shift
-            y = np.array(hist, dtype=np.float)/area
+            y = np.array(hist, dtype=float)/area
             p1, err = ffit.simpleDISSpdffit(x, y)
             y1 = ffit.funcsimpleDISSpdf(p1, x)*area
             peak = center[np.argmax(y1)]
@@ -236,9 +236,9 @@ class DynamicSpectrum(object):
 
         if simple: # Do 1D slices
             NF = len(self.F)
-            Faxis = (np.arange(-(NF-1), NF, dtype=np.float)*np.abs(dF)) #why abs?
+            Faxis = (np.arange(-(NF-1), NF, dtype=float)*np.abs(dF)) #why abs?
             NT = len(self.T)
-            Taxis = (np.arange(-(NT-1), NT, dtype=np.float)*np.abs(dT))[1:-1] #???
+            Taxis = (np.arange(-(NT-1), NT, dtype=float)*np.abs(dT))[1:-1] #???
 
 
             pout, perrs = ffit.gaussianfit(Taxis[NT//2:3*NT//2], self.acf[centerrind, NT//2:3*NT//2], baseline=True)

--- a/pypulse/singlepulse.py
+++ b/pypulse/singlepulse.py
@@ -49,7 +49,7 @@ class SinglePulse(object):
         #Define off pulse
         self.nbins = self.getNbins()
         self.bins = np.arange(self.nbins)
-        self.phases = np.arange(self.nbins, dtype=np.float)/self.nbins
+        self.phases = np.arange(self.nbins, dtype=float)/self.nbins
 
         if windowsize is not None or (mpw is None and opw is None and windowsize is None):
             # if either windowsize is set or nothing is set,
@@ -366,7 +366,7 @@ class SinglePulse(object):
         yshift = np.concatenate((yshift, [yshift[0]]))
 
         knots = u.subdivide(tdata, yshift, noise, **kwargs)
-        knots = np.array(np.sort(knots), dtype=np.int)
+        knots = np.array(np.sort(knots), dtype=int)
         knots = np.concatenate(([0], knots, [N])) #Add endpoints
 
         setsigma = False
@@ -377,7 +377,7 @@ class SinglePulse(object):
         while True:
             Nknots = len(knots)
             Narcs = Nknots-1
-            t = np.array(tdata[knots], dtype=np.float)
+            t = np.array(tdata[knots], dtype=float)
 
             # Determine the knot y-values.
             y = np.zeros_like(t)
@@ -393,7 +393,7 @@ class SinglePulse(object):
                 y[i] = f(tdata[knots[i]])
 
             if setsigma:
-                sigma = np.ones(len(y), dtype=np.float)
+                sigma = np.ones(len(y), dtype=float)
             Sigma = np.diag(sigma[:-1]) #matrix
 
             # Smoothing with Cubic Splines by D.S.G. Pollock 1999
@@ -657,7 +657,7 @@ class SinglePulse(object):
         else:
             tauds = np.copy(searchtauds)
 
-        bins = np.array(self.bins, dtype=np.float)
+        bins = np.array(self.bins, dtype=float)
 
         N_fs = np.zeros_like(tauds)
         sigma_offcs = np.zeros_like(tauds)

--- a/pypulse/utils.py
+++ b/pypulse/utils.py
@@ -39,7 +39,7 @@ def acf(array, var=False, norm_by_tau=True, lagaxis=False): #set lagaxis=True?
     elif not var:
         var = 1
 
-    lags = np.arange(-(N-1), N, dtype=np.float)
+    lags = np.arange(-(N-1), N, dtype=float)
     if norm_by_tau:
         taus = np.concatenate((np.arange(1, N+1), np.arange(N-1, 0, -1)))
         if lagaxis:
@@ -259,7 +259,7 @@ def histogram(values, interval=1.0, bottom=None, full=False, bins=None,
         center = (bins[:-1]+bins[1:])/2.0 #arithmetic mean
 
     if normalize:
-        hist = np.array(hist, dtype=np.float)/(float(interval)*np.sum(hist))
+        hist = np.array(hist, dtype=float)/(float(interval)*np.sum(hist))
 
 
     if plot:
@@ -676,7 +676,7 @@ def pbf_fourier(t, y, g=None, taud=1.0, opw=None, m=1.0, x=1.5, **kwargs):
     else:
         sigma_opw = RMS(y[opw])
 
-    t = np.array(t, dtype=np.float)
+    t = np.array(t, dtype=float)
 
     Yf = np.fft.fft(y)
     dt = np.diff(t)[0]


### PR DESCRIPTION
Starting in numpy 1.20 using aliases like np.float will throw AttributeErrors.

This is the error message for reference: 
"AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations"